### PR TITLE
feature / tab-panel-content

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,11 +7,13 @@ var browserSync = require('browser-sync').create();
 // // Static Server + watching scss/html files
 gulp.task('serve', ['sass'], function() {
  browserSync.init({
-     server: "src/",
-     directory: true,
-     routes: {
-       "/bower_components": "bower_components"
-     }
+     server: {
+       baseDir: "src/",
+       routes: {
+         "/bower_components": "./bower_components"
+       }
+     },
+     directory: true
  });
 
  gulp.watch("src/scss/*.scss", ['sass']);

--- a/src/product.html
+++ b/src/product.html
@@ -51,14 +51,34 @@
           </div> <!--.main-image-->
           <ul class="tab-row">
             <li class="active"><a href="#">Item Details</a></li><!--
-         --><li><a href="#" class="review-rating">(3,179)</a></li><!--
+         --><li><a href="#"><span>&#9733;</span>(3,179)</a></li><!--
          --><li><a href="#">Shipping Policies</a></li>
           </ul> <!--.tab-row-->
-          <div class="product-summary">
+          <div id="product-summary" class="panel-current">
             <p>Messenger bag vegan crucifix, distillery iPhone fanny pack cardigan salvia selvage Shoreditch chillwave. Sartorial Etsy viral Helvetica distillery master cleanse, bespoke fashion axe Shoreditch banjo photo booth 3 wolf moon literally typewriter chia. Kogi dreamcatcher keffiyeh, Austin Wes Anderson you probably haven't heard of them church-key banh mi. Raw denim taxidermy authentic, semiotics sartorial fixie Vice. DIY post-ironic Odd Future, tilde tattooed slow-carb flexitarian Wes Anderson cornhole narwhal migas. Cornhole farm-to-table Kickstarter, gluten-free readymade you probably haven't heard of them post-ironic Marfa ethical keytar occupy beard Austin squid.</p>
             <p>Blog four loko cold-pressed keffiyeh ennui street art chambray craft beer, photo booth +1 Schlitz quinoa. Ethical irony craft beer tilde, brunch quinoa tote bag. Wes Anderson fixie Intelligentsia, Etsy photo booth gentrify food truck McSweeney's cold-pressed small batch stumptown. Messenger bag put a bird on it keffiyeh, letterpress flannel photo booth Schlitz. Lo-fi Williamsburg fingerstache, before they sold out 3 wolf moon typewriter American Apparel sustainable 8-bit four loko. Before they sold out bitters tote bag, Shoreditch migas paleo church-key. Organic hella wayfarers, art party food truck Odd Future Neutra Bushwick mlkshk biodiesel Banksy.</p>
             <p>VHS semiotics wolf, kitsch mustache PBR&B scenester stumptown photo booth disrupt +1 bicycle rights. Intelligentsia Banksy gastropub, salvia narwhal retro seitan kogi forage deep v food truck pork belly shabby chic wolf. Ethical flexitarian PBR chillwave mixtape, bicycle rights readymade. Whatever fingerstache flannel food truck readymade, authentic sriracha tilde Pitchfork pug pickled direct trade Blue Bottle messenger bag umami. Cred plaid pop-up master cleanse, Marfa quinoa Helvetica salvia chambray. Bespoke 3 wolf moon Truffaut, occupy vegan stumptown next level keffiyeh cornhole sustainable locavore. Kale chips tofu Wes Anderson pour-over mumblecore, pork belly cray cardigan squid literally meditation Pinterest. Wayfarers Brooklyn polaroid try-hard, Kickstarter lo-fi chambray kitsch jean shorts aesthetic.</p>
-          </div> <!--.product-summary-->
+          </div> <!--#product-summary-->
+          <div id="product-reviews">
+            <aside>
+              <img src="http://lorempixel.com/45/45/people">
+              <h5>Reviewed by <br>
+                Heather</h5>
+            </aside>
+            <figure>
+              <h5>&#9733;<span>{{product.review.date}}</span></h5>
+              <p>Messenger bag vegan crucifix, distillery iPhone fanny pack cardigan salvia selvage Shoreditch chillwave. Sartorial Etsy viral Helvetica distillery master cleanse.</p>
+              <h5 class="translate">Translate</h5>
+              <div class="reviewed-item">
+                <img src="http://lorempixel.com/45/45/cats">
+                <h5>The Title of These Items are Bullshit, FINAL SALE for Annoying Bullshit Products</h5>
+              </div>
+            </figure>
+          </div> <!--#product-reviews-->
+          <div id="shipping-policies">
+            <h5>Payment Methods</h5>
+            <h5>Ready to ship in 3-5 business days</h5>
+          </div> <!--#shipping-policies-->
         </section> <!-- .left-column -->
         <aside class="right-column">
           <div class="unit-span-4 item-detail">

--- a/src/scss/_product.scss
+++ b/src/scss/_product.scss
@@ -159,12 +159,11 @@ body {
         padding: 1.25ex 2ex 0 2ex;
         text-decoration: none;
         color: #0292B5;
-      }
 
-      .review-rating:before {
-        content: "\2605";
-        color: #FFDC1E;
-        padding-right: .5ex;
+        span {
+          color: #FFDC1E;
+          padding-right: .5ex;
+        }
       }
 
       a:hover {
@@ -191,13 +190,70 @@ body {
       border-right: 1px solid #DADBD6;
     }
   }
-  .product-summary {
+  #product-summary {
     width: 85%;
     font-size: 1.75ex;
     color: #5B5B5B;
     text-align: left;
     margin-left: 2.5%;
     margin-right: 2.5%;
+  }
+
+  #product-reviews {
+    display: none;
+    width: 90%;
+
+    aside {
+      display: inline-block;
+      width: 24.5%;
+      text-align: center;
+      vertical-align: top;
+    }
+
+    figure {
+      display: inline-block;
+      width: 74%;
+      margin: 0;
+      font-size: 1.75ex;
+      color: #5B5B5B;
+
+      h5 {
+        margin-top: 0;
+        margin-bottom: 1ex;
+
+        span {
+          @extend .clearfix;
+          float: right;
+          font-weight: lighter;
+        }
+      }
+
+      .translate {
+        display: inline;
+      }
+
+      .translate:after {
+        content: "\25bc";
+        padding-left: .75ex;
+      }
+
+      .reviewed-item {
+
+        img{
+          vertical-align: baseline;
+          padding-right: 1ex;
+        }
+
+        h5 {
+          display: inline-block;
+          width: 75%;
+        }
+      }
+    }
+  }
+
+  #shipping-policies {
+    display: none;
   }
 }
 


### PR DESCRIPTION
- [x] Update html with content for additional two tabs in the reference implementation (reviews, shipping & policies)
  - [x] `display: none` by default
  - [x] include `class=panel-current` on item details panel; sets panel to `display: block`
- [x] Style with Sass as appropriate
